### PR TITLE
feat: 괄호 감싸기 플러그인 설치 및 키맵 설정 #32

### DIFF
--- a/lua/plugins/parenthesis.lua
+++ b/lua/plugins/parenthesis.lua
@@ -1,0 +1,20 @@
+return {
+	"kylechui/nvim-surround",
+	version = "*", -- Use for stability; omit to use `main` branch for the latest features
+	event = "VeryLazy",
+	config = function()
+		require("nvim-surround").setup({})
+
+		-- NOTE: ``, "", '', <>, {}, [], (),  // 입력시 자동 감싸기
+		-- 참고: https://www.reddit.com/r/neovim/comments/18x6xk9/introducing_visualsurroundnvim/
+		local v_chars = { "(", ")", "[", "]", "<", ">", "{", "}", "'", '"', "`", "/" }
+		for _, char in pairs(v_chars) do
+			vim.keymap.set("v", "<leader>" .. char, "<Plug>(nvim-surround-visual)" .. char, { desc = "wrap " .. char })
+		end
+
+		vim.keymap.set("v", "<leader>t", "<Plug>(nvim-surround-visual)t", { desc = "wrap [t]age" })
+		vim.keymap.set("v", "<leader>f", "<Plug>(nvim-surround-visual)f", { desc = "wrap [f]unction" })
+
+		-- TODO: ****는 비주얼 모드에서 *을 선택하는 것으로 앞뒤에 2개 추가하기
+	end,
+}


### PR DESCRIPTION
## Motivation ✨

- 마크다운으로 책읽고 필기하고 또 예제도 직접 손코딩 해보는데 감싸는 기능이 없어서 작업이 비효율적이 었던 문제를 플러그인과 키맵으로 해결하고자 함

<br/>

## Key Changes 🔑

- 비주얼 모드에 선택된 텍스트는 앞뒤에 괄호, 함수, 태그로 감쌀 수 있음

<br/>

## To Reviewers 🙏

- 그냥 파일 하나 추가됨

<br/>
